### PR TITLE
[Feat] #17 로그인 기능 구현

### DIFF
--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginView.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginView.swift
@@ -13,11 +13,11 @@ final class LoginView: BaseView {
     private let logoImageView = UIImageView()
     private let textLogoImageView = UIImageView()
     
-    private let idTextField = UITextField()
+    let idTextField = UITextField()
     private let idUnderLineView = UIView()
     private let idGuideLabel = UILabel()
     
-    private let passwordTextField = UITextField()
+    let passwordTextField = UITextField()
     private let passwordUnderLineView = UIView()
     private let passwordGuideLabel = UILabel()
     
@@ -57,7 +57,7 @@ final class LoginView: BaseView {
         passwordTextField.placeholder = "비밀번호"
         passwordTextField.clearButtonMode = .whileEditing // 입력 중 x 버튼 생성
         passwordTextField.isSecureTextEntry = true // 문자열이 * 처리됨
-        passwordTextField.textContentType = .oneTimeCode // auto fill 제한
+        passwordTextField.textContentType = .password
         passwordTextField.autocapitalizationType = .none // 첫 영문자를 항상 소문자로 시작
         self.addSubview(passwordTextField)
         

--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewController.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewController.swift
@@ -43,8 +43,8 @@ final class LoginViewController: UIViewController {
     /// 버튼 이벤트를 ViewModel로 전달
     private func bindViewModel() {
         let input = LoginViewModel.Input(
-            loginButtonTap: loginView.startButton.rx.tap.asObservable(),
-            signUpButtonTap: loginView.signUpButton.rx.tap.asObservable(),
+            id: loginView.idTextField.rx.text.orEmpty.asDriver(),
+            password: loginView.passwordTextField.rx.text.orEmpty.asDriver(),
             loginButtonTap: loginView.startButton.rx.tap.asSignal(),
             signUpButtonTap: loginView.signUpButton.rx.tap.asSignal(),
             adminButtonTap: loginView.adminButton.rx.tap.asSignal()
@@ -52,6 +52,7 @@ final class LoginViewController: UIViewController {
         
         let output = viewModel.transform(input: input)
         
+        // 로그인 성공 → 메인 전환
         output.moveToMain
             .emit(onNext: { _ in
                 guard let sceneDelegate = UIApplication.shared.connectedScenes
@@ -73,6 +74,7 @@ final class LoginViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        // 회원가입
         output.moveToSignUp
             .emit(onNext: { [weak self] _ in
                 let vc = SignUpViewController()
@@ -83,6 +85,7 @@ final class LoginViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        // 관리자(테스트)
         output.moveToAdmin
             .emit(onNext: { [weak self] _ in
                 let vc = AdminViewController()
@@ -92,5 +95,22 @@ final class LoginViewController: UIViewController {
                 self?.present(modalNav, animated: true)
             })
             .disposed(by: disposeBag)
+        
+        // 에러 Alert
+        output.showError
+            .emit(onNext: { [weak self] msg in
+                let ac = UIAlertController(title: "로그인 실패", message: msg, preferredStyle: .alert)
+                ac.addAction(UIAlertAction(title: "확인", style: .default))
+                self?.present(ac, animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        // 버튼 활성화
+//        output.isLoginEnabled
+//            .drive(onNext: { [weak self] enabled in
+//                self?.loginView.startButton.isEnabled = enabled
+//                self?.loginView.startButton.alpha = enabled ? 1.0 : 0.5
+//            })
+//            .disposed(by: disposeBag)
     }
 }

--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewController.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewController.swift
@@ -45,42 +45,43 @@ final class LoginViewController: UIViewController {
         let input = LoginViewModel.Input(
             loginButtonTap: loginView.startButton.rx.tap.asObservable(),
             signUpButtonTap: loginView.signUpButton.rx.tap.asObservable(),
+            loginButtonTap: loginView.startButton.rx.tap.asSignal(),
+            signUpButtonTap: loginView.signUpButton.rx.tap.asSignal(),
             adminButtonTap: loginView.adminButton.rx.tap.asSignal()
         )
         
         let output = viewModel.transform(input: input)
         
-        output.navigation
-            .drive(onNext: { [weak self] nav in
-                switch nav {
-                case .login:
-                    guard let sceneDelegate = UIApplication.shared.connectedScenes
-                        .first?.delegate as? SceneDelegate else { return }
-                    
-                    // 로그인 이후 메인
-                    let mainVC = MainViewController() // 로그인 후 메인화면
-                    
-                    // SceneDelegate 의 window 없는지 확인
-                    guard let window = sceneDelegate.window else { return }
-                    
-                    // 화면 전환
-                    UIView.transition(with: window,
-                                      duration: 0.5,
-                                      options: .transitionCrossDissolve,
-                                      animations: {
-                        sceneDelegate.window?.rootViewController = mainVC
-                    })
-                case .signUp:
-                    let vc = SignUpViewController()
-                    let modalNav = UINavigationController(rootViewController: vc)
-                    modalNav.modalPresentationStyle = .fullScreen
-                    modalNav.modalTransitionStyle = .coverVertical
-                    self?.present(modalNav, animated: true)
-                    
-                case .error(let message):
-                    print("오류 발생: \(message)")
-                }
-            }).disposed(by: disposeBag)
+        output.moveToMain
+            .emit(onNext: { _ in
+                guard let sceneDelegate = UIApplication.shared.connectedScenes
+                    .first?.delegate as? SceneDelegate else { return }
+                
+                // 로그인 이후 메인
+                let vc = MainViewController() // 로그인 후 메인화면
+                
+                // SceneDelegate 의 window 없는지 확인
+                guard let window = sceneDelegate.window else { return }
+                
+                // 화면 전환
+                UIView.transition(with: window,
+                                  duration: 0.5,
+                                  options: .transitionCrossDissolve,
+                                  animations: {
+                    sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: vc)
+                })
+            })
+            .disposed(by: disposeBag)
+        
+        output.moveToSignUp
+            .emit(onNext: { [weak self] _ in
+                let vc = SignUpViewController()
+                let modalNav = UINavigationController(rootViewController: vc)
+                modalNav.modalPresentationStyle = .fullScreen
+                modalNav.modalTransitionStyle = .coverVertical
+                self?.present(modalNav, animated: true)
+            })
+            .disposed(by: disposeBag)
         
         output.moveToAdmin
             .emit(onNext: { [weak self] _ in

--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewModel.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewModel.swift
@@ -17,8 +17,8 @@ final class LoginViewModel: ViewModelType {
     }
     
     struct Input {
-        let loginButtonTap: Observable<Void>
-        let signUpButtonTap: Observable<Void>
+        let id: Driver<String>
+        let password: Driver<String>
         let loginButtonTap: Signal<Void>
         let signUpButtonTap: Signal<Void>
         let adminButtonTap: Signal<Void>
@@ -28,30 +28,89 @@ final class LoginViewModel: ViewModelType {
         let moveToMain: Signal<Void>
         let moveToSignUp: Signal<Void>
         let moveToAdmin: Signal<Void>
+        let showError: Signal<String>
+//        let isLoginEnabled: Driver<Bool>
     }
     
     var disposeBag = DisposeBag()
     
     func transform(input: Input) -> Output {
+        let creds = Driver.combineLatest(input.id, input.password)
         
-        // 로그인 버튼 탭
-        // id, pw 필드에 값을 본다.
-        // 비어있으면 비어있다는 에러 출력
-        // id, pw 필드에 값이 모두 있다면
-        // id, pw 값과 coredata 의 정보와 일치하는지 확인
-        //
-        let loginButtonTap = input.loginButtonTap
-            .throttle(.milliseconds(500))
-            .map { Navigation.main }
+        // 버튼 활성화: 공백이 아니면 true
+//        let isLoginEnabled = creds
+//            .map { !$0.0.trimmingCharacters(in: .whitespaces).isEmpty && // TODO: trimmingCharacters 가 뭐냐?
+//                !$0.1.trimmingCharacters(in: .whitespaces).isEmpty }
+//            .distinctUntilChanged()
         
-        let signUpButtonTap = input.signUpButtonTap
+        let errorRelay = PublishRelay<String>()
+        let successRelay = PublishRelay<Void>()
+        
+        // 탭 시 최신 id/pw 로 로그인 시도
+        input.loginButtonTap
             .throttle(.milliseconds(500))
-            .map { Navigation.signUp }
+            .withLatestFrom(creds.asSignal(onErrorSignalWith: .empty()))
+            .flatMapLatest { id, pw -> Signal<Void> in
+                // 빈값 가드
+                let idTrim = id.trimmingCharacters(in: .whitespaces)
+                let pwTrim = pw.trimmingCharacters(in: .whitespaces)
+                guard !idTrim.isEmpty, !pwTrim.isEmpty else {
+                    errorRelay.accept(LoginInError.emptyFields.localizedDescription)
+                    return .empty()
+                }
+                
+                return CoreDataManager.shared.verifyLogin(id: idTrim, password: pwTrim)
+                    .asSignal(onErrorSignalWith: .deferred {
+                        errorRelay.accept("아이디 또는 비밀번호가 올바르지 않습니다.")
+                        return .empty()
+                    })
+                    .map { _ in () } // 성공
+            }
+            .emit(to: successRelay)
+            .disposed(by: disposeBag)
+        
+//        let loginButtonTap = input.loginButtonTap
+//            .throttle(.milliseconds(500))
+//            .map { Navigation.main }
         
         return Output(
-            moveToMain: input.loginButtonTap,
+            moveToMain: successRelay.asSignal(),
             moveToSignUp: input.signUpButtonTap,
-            moveToAdmin: input.adminButtonTap
+            moveToAdmin: input.adminButtonTap,
+            showError: errorRelay.asSignal()
+//            isLoginEnabled: isLoginEnabled
         )
     }
+    
+    /// 로그인 처리
+    /// - 로그인 버튼을 누르면
+    /// - 아이디와 비밀번호를 코어데이터에 있는 계정 정보를 불러와 비교
+    /// - 아이디와 비밀번호가 일치하면 main 화면으로 이동
+    /// - 정보가 틀리면 alert 띄움
+    func login() {
+        
+    }
 }
+
+// TODO: 로딩 인디케이터 추가하기
+//final class ActivityIndicator: SharedSequenceConvertibleType {
+//    typealias Element = Bool
+//    typealias SharingStrategy = DriverSharingStrategy
+//
+//    private let relay = BehaviorRelay(value: false)
+//    
+//    func trackActivity<T>(_ source: Single<T>) -> Single<T> {
+//        return Single.create { observer in
+//            self.relay.accept(true)
+//            let d = source.subscribe { event in
+//                self.relay.accept(false)
+//                observer(event)
+//            }
+//            return Disposables.create { d.dispose() }
+//        }
+//    }
+//    func asSharedSequence() -> SharedSequence<SharingStrategy, Element> {
+//        relay.asDriver()
+//    }
+//    func asDriver() -> Driver<Bool> { relay.asDriver() }
+//}

--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewModel.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Login/LoginViewModel.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 final class LoginViewModel: ViewModelType {
     enum Navigation {
-        case login
+        case main
         case signUp
         case error(String)
     }
@@ -19,31 +19,38 @@ final class LoginViewModel: ViewModelType {
     struct Input {
         let loginButtonTap: Observable<Void>
         let signUpButtonTap: Observable<Void>
+        let loginButtonTap: Signal<Void>
+        let signUpButtonTap: Signal<Void>
         let adminButtonTap: Signal<Void>
     }
     
     struct Output {
-        let navigation: Driver<Navigation>
+        let moveToMain: Signal<Void>
+        let moveToSignUp: Signal<Void>
         let moveToAdmin: Signal<Void>
     }
     
     var disposeBag = DisposeBag()
     
-    let stepRelay = PublishRelay<Navigation>()
-    
     func transform(input: Input) -> Output {
-        input.loginButtonTap
-            .subscribe(onNext: { [weak self] in
-                self?.stepRelay.accept(.login)
-            }).disposed(by: disposeBag)
         
-        input.signUpButtonTap
-            .subscribe(onNext: { [weak self] in
-                self?.stepRelay.accept(.signUp)
-            }).disposed(by: disposeBag)
+        // 로그인 버튼 탭
+        // id, pw 필드에 값을 본다.
+        // 비어있으면 비어있다는 에러 출력
+        // id, pw 필드에 값이 모두 있다면
+        // id, pw 값과 coredata 의 정보와 일치하는지 확인
+        //
+        let loginButtonTap = input.loginButtonTap
+            .throttle(.milliseconds(500))
+            .map { Navigation.main }
+        
+        let signUpButtonTap = input.signUpButtonTap
+            .throttle(.milliseconds(500))
+            .map { Navigation.signUp }
         
         return Output(
-            navigation: stepRelay.asDriver(onErrorJustReturn: .error("알 수 없는 오류")),
+            moveToMain: input.loginButtonTap,
+            moveToSignUp: input.signUpButtonTap,
             moveToAdmin: input.adminButtonTap
         )
     }

--- a/CoreDataAuth/CoreDataAuth/Service/CoreData/CoreDataManager.swift
+++ b/CoreDataAuth/CoreDataAuth/Service/CoreData/CoreDataManager.swift
@@ -11,6 +11,19 @@ import RxSwift
 
 enum CoreDataError: Error { case notFound }
 
+// 로그인 에러 정의
+enum LoginInError: LocalizedError {
+    case wrongPassword
+    case emptyFields
+
+    var errorDescription: String? {
+        switch self {
+        case .wrongPassword: return "아이디 또는 비밀번호가 올바르지 않습니다."
+        case .emptyFields: return "아이디와 비밀번호를 입력해주세요."
+        }
+    }
+}
+
 final class CoreDataManager {
     // MARK: - Propertys
     static let shared = CoreDataManager()
@@ -26,7 +39,7 @@ final class CoreDataManager {
     /// 사용자 정보 생성
     func createAppUser(id: String, nickname: String, password: String) -> Completable {
         return Completable.create { completable in
-            if self.fetchUser(id: id, password: password) != nil {
+            if self.fetchUserID(id: id) != nil {
                 // 이미 존재하는 경우
                 completable(.error(SignUpViewModel.SignUpError.duplicateID))
             } else {
@@ -51,6 +64,35 @@ final class CoreDataManager {
         } catch {
             print("Login Fetch Failed: \(error)")
             return nil
+        }
+    }
+    
+    /// 로그인 시, 계정정보 비교하기
+    func verifyLogin(id: String, password: String) -> Single<UserEntity> {
+        return Single.create { single in
+            let request: NSFetchRequest<UserEntity> = UserEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id)
+            request.fetchLimit = 1
+            
+            self.context.perform {
+                do {
+                    guard let user = try self.context.fetch(request).first,
+                          let hashed = user.passwordHash
+                    else {
+                        single(.failure(CoreDataError.notFound)) // ID 없음
+                        return
+                    }
+                    
+                    if self.hasher.verify(plain: password, hashed: hashed) {
+                        single(.success(user))
+                    } else {
+                        single(.failure(LoginInError.wrongPassword))
+                    }
+                } catch {
+                    single(.failure(error))
+                }
+            }
+            return Disposables.create()
         }
     }
     


### PR DESCRIPTION
close #17 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 1. 로그인 에러 정의
``` swift
// 로그인 에러 정의
enum LoginInError: LocalizedError {
    case wrongPassword // 계정 정보가 틀렸을 때
    case emptyFields // 아이디, 패스워드 입력을 안했을 때

    var errorDescription: String? {
        switch self {
        case .wrongPassword: return "아이디 또는 비밀번호가 올바르지 않습니다."
        case .emptyFields: return "아이디와 비밀번호를 입력해주세요."
        }
    }
}
```

### 2. ID 중복 로직 변경
#### 문제점
- fetchUser(id:password:) 는 평문 비번을 predicate에 넣고 있어서 해시 검증이 안 됨.
#### 해결
- ID 중복은 fetchUserID 로만 판단.
#### 변경 전
``` swift
if self.fetchUser(id: id, password: password)
```
#### 변경 후
``` swift
if self.fetchUserID(id: id)
```

### 3. 로그인 로직 구현
#### CoreData
- ID, PW 입력 받아 CoreData에 저장된 계정 정보와 일치하는지 확인
- PW는 해시헬퍼 메서드를 이용하여 검증한다.
#### ViewModel
- 사용자가 입력한 ID, PW 를 CoreData에 저장된 계정 정보와 비교한다.
- 검증이 성공하면 successRelay에 값을 방출하여, Main 화면으로 이동하게 한다.

## *📸 Screenshot*
<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*
<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->
### ID / PW 입력 안했을 때
<img width="476" height="888" alt="image" src="https://github.com/user-attachments/assets/3095ee6e-957d-4d44-bbb8-f0a9c4cc0e26" />

### ID / PW 가 틀렸을 때
<img width="476" height="888" alt="image" src="https://github.com/user-attachments/assets/5b82de33-6c82-4cb0-a967-ae265a6d27fb" />

### 로그인 정보가 올바를 때
![Simulator Screen Recording - iPhone 13 mini - 2025-09-10 at 19 50 19](https://github.com/user-attachments/assets/715e8518-562c-4ef2-8ec8-2283cee7d022)

- 코드리뷰 부탁드립니다.

## *✅ Checklist*
<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
