### PR TITLE
[Feat] #14 회원 탈퇴 기능 구현

### DIFF
--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Main/MainViewController.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Main/MainViewController.swift
@@ -16,8 +16,9 @@ final class MainViewController: UIViewController {
     private let mainView = MainView()
     private let viewModel = MainViewModel()
     private var disposeBag = DisposeBag()
-    private let logoutButtonTrigger = PublishRelay<Void>()
-    private let unregisterButtonTrigger = PublishRelay<Void>()
+    
+    // "탈퇴 확인"을 흘려보낼 릴레이
+    private let deleteConfirmRelay = PublishRelay<Void>()
     
     // MARK: - LifeCycle
     override func loadView() {
@@ -32,24 +33,15 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        bindButtons()
         bindViewModel()
+        bindDeleteAlert()  // 탈퇴 확인 알럿 트리거
     }
     
     // MARK: - Methods
-    func bindButtons() {
-        mainView.logoutButton.rx.tap
-            .bind(to: logoutButtonTrigger)
-            .disposed(by: disposeBag)
-        
-        mainView.unregisterButton.rx.tap
-            .bind(to: unregisterButtonTrigger)
-            .disposed(by: disposeBag)
-    }
-    
     func bindViewModel() {
         let input = MainViewModel.Input(
-            logoutTap: mainView.logoutButton.rx.tap.asSignal()
+            logoutTap: mainView.logoutButton.rx.tap.asSignal(),
+            deleteConfirmTap: deleteConfirmRelay.asSignal()
         )
         
         let output = viewModel.transform(input: input)
@@ -57,5 +49,31 @@ final class MainViewController: UIViewController {
         output.moveToLogin
             .emit(onNext: { AppRouter.toLogin() })   // 루트 교체
             .disposed(by: disposeBag)
+        
+        output.showError
+            .emit(onNext: { [weak self] msg in
+                let ac = UIAlertController(title: "오류", message: msg, preferredStyle: .alert)
+                ac.addAction(UIAlertAction(title: "확인", style: .default))
+                self?.present(ac, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
+    
+    /// 탈퇴 버튼 탭 → 확인 알럿 → '탈퇴' 선택 시 deleteConfirmRelay 방출
+        private func bindDeleteAlert() {
+            mainView.unregisterButton.rx.tap
+                .bind(onNext: { [weak self] in
+                    let ac = UIAlertController(
+                        title: "회원 탈퇴",
+                        message: "정말 탈퇴하시겠어요?",
+                        preferredStyle: .alert
+                    )
+                    ac.addAction(UIAlertAction(title: "취소", style: .cancel))
+                    ac.addAction(UIAlertAction(title: "탈퇴", style: .destructive, handler: { _ in
+                        self?.deleteConfirmRelay.accept(())
+                    }))
+                    self?.present(ac, animated: true)
+                })
+                .disposed(by: disposeBag)
+        }
 }

--- a/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Main/MainViewModel.swift
+++ b/CoreDataAuth/CoreDataAuth/Presentation/Scenes/Main/MainViewModel.swift
@@ -18,10 +18,12 @@ final class MainViewModel: ViewModelType {
     
     struct Input {
         let logoutTap: Signal<Void> // 로그아웃
+        let deleteConfirmTap: Signal<Void>  // “정말 탈퇴” 확인 버튼 탭
     }
     
     struct Output {
         let moveToLogin: Signal<Void>
+        let showError: Signal<String>
     }
     
     // MARK: - Propertys
@@ -35,17 +37,47 @@ final class MainViewModel: ViewModelType {
     
     // MARK: - Methods
     func transform(input: Input) -> Output {
-        let moveToLogin = input.logoutTap
+        let errorRelay = PublishRelay<String>()
+        
+        // 로그아웃
+        let logout: Signal<Void> = input.logoutTap
             .throttle(.milliseconds(500))
             .do(onNext: { [weak self] in
                 self?.session.clear()   // 세션 제거
             })
             .map { }                    // Void로 방출
-            .asSignal(onErrorSignalWith: .empty())
         
+        // 회원탈퇴
+        let delete: Signal<Void> = input.deleteConfirmTap
+            .throttle(.milliseconds(500))
+            .flatMapLatest { [weak self] _ -> Signal<Void> in
+                guard let self = self,
+                      let uid = self.session.currentUserId, !uid.isEmpty
+                else {
+                    errorRelay.accept("로그인 정보가 없습니다.")
+                    return .empty()
+                }
+                // Completable -> Signal<Void>
+                return CoreDataManager.shared.deleteAppUser(withId: uid)
+                    .andThen(Single.just(()))
+                    .asSignal(onErrorRecover: { error in
+                        switch error {
+                        case CoreDataError.notFound:
+                            errorRelay.accept("계정을 찾을 수 없습니다.")
+                        default:
+                            errorRelay.accept("탈퇴 중 오류가 발생했습니다.")
+                        }
+                        return .empty()
+                    })
+            }
+            .do(onNext: { [weak self] in self?.session.clear() })
+        
+        // 3) 두 흐름을 합쳐서 "로그인으로 이동" 신호 하나로
+        let moveToLogin = Signal.merge(logout, delete)
         
         return Output(
-            moveToLogin: moveToLogin
+            moveToLogin: moveToLogin,
+            showError: errorRelay.asSignal()
         )
     }
 }

--- a/CoreDataAuth/CoreDataAuth/Service/CoreData/CoreDataManager.swift
+++ b/CoreDataAuth/CoreDataAuth/Service/CoreData/CoreDataManager.swift
@@ -145,9 +145,28 @@ final class CoreDataManager {
     // MARK: - Update
     
     // MARK: - Delete
-    func deleteAppUser(user: UserEntity) {
-        context.delete(user)
-        saveContext()
+    func deleteAppUser(withId id: String) -> Completable {
+        return Completable.create { completable in
+            let request: NSFetchRequest<UserEntity> = UserEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id)
+            request.fetchLimit = 1
+            
+            self.context.perform {
+                do {
+                    guard let user = try self.context.fetch(request).first else {
+                        completable(.error(CoreDataError.notFound))
+                        return
+                    }
+                    self.context.delete(user)
+                    try self.context.save()
+                    completable(.completed)
+                } catch {
+                    self.context.rollback()
+                    completable(.error(error))
+                }
+            }
+            return Disposables.create()
+        }
     }
     
     // MARK: - Save


### PR DESCRIPTION
close #14 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### CoreData 데이터 삭제 로직 수정
- 데이터 삭제 로직을 RX로 사용할 수 있게 Completable로 변경
- 제거 대상의 ID를 기준으로 데이터 삭제하도록 로직 수정
### ViewModel 회원탈퇴 로직 추가
- 회원 탈퇴 에러처리 로직 추가
- 코어데이터 회원 데이터 삭제 진행 로직 추가
- 로그아웃과 회원탈퇴 흐름을 Merge로 묶어서 로그아웃 회면으로 가도록 수정
### ViewController 회원탈퇴 로직 추가
- 회원탈퇴 버튼 탭 시, 알림창이 띄우는 로직 추가
- 알림창에서 탈퇴를 누르면 이벤트를 방출하는 로직 추가
- 이벤트가 방출되면 회원 정보가 삭제됨

## *📸 Screenshot*
<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->
![Simulator Screen Recording - iPhone 13 mini - 2025-09-24 at 17 21 20](https://github.com/user-attachments/assets/065d642b-d7c6-4d3c-a79a-e45c6a6dac96)

## *📢 To Reviewers*
<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->

- 코드리뷰 부탁드립니다.

## *✅ Checklist*
<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->

- [x]  주석 및 프린트문 제거 확인.
- [x]  컨벤션 준수 확인.
